### PR TITLE
Accept filters on map legend group data entries

### DIFF
--- a/cave_utils/api/maps.py
+++ b/cave_utils/api/maps.py
@@ -337,6 +337,7 @@ class maps_data_star_legendGroups_star_data_star(ApiValidator):
         colorByOptions: list | None = None,
         sizeByOptions: list | None = None,
         icon: str | None = None,
+        filters: list[dict] | None = None,
         **kwargs,
     ):
         """
@@ -440,6 +441,9 @@ class maps_data_star_legendGroups_star_data_star(ApiValidator):
                 * Arc layer icons are determined by `lineStyle`.
                 * Shape layer icons are always the default icon.
                 * This attribute applies exclusively to `node` layers
+        * **`filters`**: `[list[dict]]` = `None` &rarr; A list of filter dictionaries to apply to the data layer.
+            * **Note**: The contents of each filter dictionary are not yet validated. See the
+              matching TODO in `cave_utils.api.pages.pages_data_star`.
         """
         return {
             "kwargs": kwargs,

--- a/test/api_examples/map_nodes.py
+++ b/test/api_examples/map_nodes.py
@@ -57,6 +57,24 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                     "sizeBy": "capacity",
                                     "sizeByOptions": ["capacity"],
                                     "icon": "fa6/FaWarehouse",
+                                    # Only show warehouses with a capacity greater than 90
+                                    "filters": [
+                                        {
+                                            "id": 0,
+                                            "type": "group",
+                                            "groupId": 0,
+                                            "logic": "and",
+                                            "edit": False,
+                                        },
+                                        {
+                                            "id": 1,
+                                            "type": "rule",
+                                            "parentGroupId": 0,
+                                            "prop": "capacity",
+                                            "option": "gt",
+                                            "value": "90",
+                                        },
+                                    ],
                                 },
                             },
                         },


### PR DESCRIPTION
Fixes #109.

## What happens now

Any map whose legend group data entry carries a `filters` list produces a validator warning:

```
{'path': ['maps', 'data', 'populationMap', 'legendGroups', 'populationDensities', 'data', 'state'],
 'msg': "Unknown Fields: ['filters']", 'level': 'warning'}
```

`maps_data_star_legendGroups_star_data_star.spec` does not declare `filters`, so it falls through to `**kwargs` and `validator_utils` reports it as an unknown field.

I took the filter object from `cave_api/examples/other_examples/future/map_nodes_filter.py` in cave_app, since that is where the intended shape is written down. Dropping that exact object onto an otherwise clean example takes the log from 0 entries to the warning above, so the example in cave_app cannot currently be validated without it.

## The change

`filters: list[dict] | None = None` on the legend group data spec, plus a docs entry.

Charts already accept `filters` this way in `pages.pages_data_star`, so this only brings the map side in line. I deliberately did not validate the contents of the filter dictionaries: `pages.py` carries `# TODO: Document and validate filters` and I did not want to invent a schema for the rule and group objects ahead of you. The docstring notes that and points at the existing TODO. Happy to follow up with real validation of the filter objects if you tell me what the accepted `option` and `type` values should be.

## Test

`test/api_examples/map_nodes.py` now carries the same filter shape as the cave_app example. The existing `test_validator` test walks every example and asserts an empty log, so this is covered without new test machinery.

Fails before the spec change:

```
E   AssertionError: Validator tests failed for one or more examples.
1 failed in 1.29s
```

Passes after:

```
11 passed in 1.48s
```

Checked on Python 3.12. `black --line-length 100` reports both files unchanged.