### PR TITLE
Accept filters on map legend group data entries

### DIFF
--- a/cave_utils/api/maps.py
+++ b/cave_utils/api/maps.py
@@ -337,6 +337,7 @@ class maps_data_star_legendGroups_star_data_star(ApiValidator):
         colorByOptions: list | None = None,
         sizeByOptions: list | None = None,
         icon: str | None = None,
+        filters: list[dict] | None = None,
         **kwargs,
     ):
         """
@@ -440,6 +441,9 @@ class maps_data_star_legendGroups_star_data_star(ApiValidator):
                 * Arc layer icons are determined by `lineStyle`.
                 * Shape layer icons are always the default icon.
                 * This attribute applies exclusively to `node` layers
+        * **`filters`**: `[list[dict]]` = `None` &rarr; A list of filter dictionaries to apply to the data layer.
+            * **Note**: The contents of each filter dictionary are not yet validated. See the
+              matching TODO in `cave_utils.api.pages.pages_data_star`.
         """
         return {
             "kwargs": kwargs,

--- a/test/api_examples/map_nodes.py
+++ b/test/api_examples/map_nodes.py
@@ -57,6 +57,24 @@ def execute_command(session_data, socket, command="init", **kwargs):
                                     "sizeBy": "capacity",
                                     "sizeByOptions": ["capacity"],
                                     "icon": "fa6/FaWarehouse",
+                                    # Only show warehouses with a capacity greater than 90
+                                    "filters": [
+                                        {
+                                            "id": 0,
+                                            "type": "group",
+                                            "groupId": 0,
+                                            "logic": "and",
+                                            "edit": False,
+                                        },
+                                        {
+                                            "id": 1,
+                                            "type": "rule",
+                                            "parentGroupId": 0,
+                                            "prop": "capacity",
+                                            "option": "gt",
+                                            "value": "90",
+                                        },
+                                    ],
                                 },
                             },
                         },


### PR DESCRIPTION
The api validator warns "Unknown Fields: ['filters']" for any map whose legend group data entry carries a filters list, because maps_data_star_legendGroups_star_data_star.spec does not declare the field and it falls through to kwargs.

Chart layouts already accept filters the same way in pages.pages_data_star, so this brings the map side in line rather than introducing anything new. The filter objects themselves are still not validated, matching the existing TODO in pages.py.

The map_nodes example now carries the filter shape used by the map_nodes_filter example in cave_app, which reproduces the warning through the existing validator test.

Fixes #109